### PR TITLE
Allow customization of syntax highlighting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Now this plug-in will free you from those commands and bring back the power of u
  1. Live updated diff panel.
  1. Highlight for changed text.
  1. Revert to a specific change by a single mouse click or key stroke.
- 1. Customizable hotkeys.
+ 1. Customizable hotkeys and highlighting.
  1. Display changes in diff panel.
 
 ### [Download](https://github.com/mbbill/undotree/tags)

--- a/syntax/undotree.vim
+++ b/syntax/undotree.vim
@@ -19,19 +19,19 @@ syn match UndotreeHelpTitle '===.*===' contained
 syn match UndotreeSavedSmall ' \zss\ze '
 syn match UndotreeSavedBig ' \zsS\ze '
 
-hi link UndotreeNode Question
-hi link UndotreeNodeCurrent Statement
-hi link UndotreeTimeStamp Function
-hi link UndotreeFirstNode Function
-hi link UndotreeBranch Constant
-hi link UndotreeSeq Comment
-hi link UndotreeCurrent Statement
-hi link UndotreeNext Type
-hi link UndotreeHead Identifier
-hi link UndotreeHelp Comment
-hi link UndotreeHelpKey Function
-hi link UndotreeHelpTitle Type
-hi link UndotreeSavedSmall WarningMsg
-hi link UndotreeSavedBig MatchParen
+hi def link UndotreeNode Question
+hi def link UndotreeNodeCurrent Statement
+hi def link UndotreeTimeStamp Function
+hi def link UndotreeFirstNode Function
+hi def link UndotreeBranch Constant
+hi def link UndotreeSeq Comment
+hi def link UndotreeCurrent Statement
+hi def link UndotreeNext Type
+hi def link UndotreeHead Identifier
+hi def link UndotreeHelp Comment
+hi def link UndotreeHelpKey Function
+hi def link UndotreeHelpTitle Type
+hi def link UndotreeSavedSmall WarningMsg
+hi def link UndotreeSavedBig MatchParen
 
 " vim: set et fdm=marker sts=4 sw=4:


### PR DESCRIPTION
By using :hi def link instead of :hi def, it is possible to predefine syntax overrides in one's .vimrc. Undotree will only set the highlighting for items that haven't yet been defined.

PS: My customizations are:
highlight link UndotreeBranch Normal
highlight link UndotreeNode Normal
highlight link UndotreeSeq Constant
