### PR TITLE
ENH: Expose plugin state via UndotreeIsVisible().

### DIFF
--- a/plugin/undotree.vim
+++ b/plugin/undotree.vim
@@ -1178,6 +1178,9 @@ function! UndotreeToggle()
     call t:undotree.Toggle()
     call s:log("<<< UndotreeToggle() leave")
 endfunction
+function! UndotreeIsVisible()
+    return (exists('t:undotree') && t:undotree.IsVisible())
+endfunction
 
 
 "let s:auEvents = "InsertEnter,InsertLeave,WinEnter,WinLeave,CursorMoved"


### PR DESCRIPTION
I have a custom key mapping that toggles different sidebar panels (Tagbar, Project, BufExplorer, and now Undotree) on / off. For that, I need a predicate function that determines whether the plugin is currently active, i.e. shows its window(s). This small public function exposes this information which was previously inaccessible in the script-local objects.
