### PR TITLE
Undotree should work with plugins that fold diffs.

### DIFF
--- a/plugin/undotree.vim
+++ b/plugin/undotree.vim
@@ -1108,7 +1108,6 @@ function! s:diffpanel.Show()
     setlocal buftype=nowrite
     setlocal bufhidden=delete
     setlocal nowrap
-    setlocal foldcolumn=0
     setlocal nobuflisted
     setlocal nospell
     setlocal nonumber
@@ -1121,6 +1120,9 @@ function! s:diffpanel.Show()
 
     " syntax need filetype autocommand
     setfiletype diff
+    setlocal foldcolumn=0
+    setlocal nofoldenable
+
     call self.BindAu()
     call t:undotree.SetFocus()
     call winrestview(savedview)


### PR DESCRIPTION
Some plugins (f.i. [vim-diff-fold](https://github.com/sgeb/vim-diff-fold)) fold diffs by default.  If such a plugin is installed
along with undotree, `diffpanel.Show()` sets the filetype for
diffpanel to `diff`, which results in a big, happy, closed fold.  Then
`undotree.Draw()` helpfully tries to deletes the last line in the diff
buffer, believing it empty.  Except, said line is now the fold.

The patch addresses this problem by opening the fold, if any.  Perhaps
a better fix would be to make sure the deleted line is actually empty
before removing it.
