### PR TITLE
Wrap the :autocmd in a custom :augroup.

### DIFF
--- a/plugin/undotree.vim
+++ b/plugin/undotree.vim
@@ -1326,7 +1326,9 @@ endfunction
 
 "let s:auEvents = "InsertEnter,InsertLeave,WinEnter,WinLeave,CursorMoved"
 let s:auEvents = "BufEnter,InsertLeave,CursorMoved,BufWritePost"
-exec "au ".s:auEvents." * call UndotreeUpdate()"
+augroup Undotree
+    exec "au! ".s:auEvents." * call UndotreeUpdate()"
+augroup END
 
 "=================================================
 " User commands.


### PR DESCRIPTION
This avoids redefining the `UndotreeUpdate()` hook again and again when reloading the plugin during development, and is customary for plugins. It also makes it easier for the user to identify the hook source and to disable it manually.
