### PR TITLE
Avoid clobbering the original buffer's alternate file.

### DIFF
--- a/plugin/undotree.vim
+++ b/plugin/undotree.vim
@@ -534,7 +534,7 @@ function! s:undotree.Show()
         let cmd = "botright vertical" .
                     \self.width . ' new ' . self.bufname
     endif
-    call s:exec("silent ".cmd)
+    call s:exec("silent keepalt ".cmd)
     call self.SetFocus()
     setlocal winfixwidth
     setlocal noswapfile


### PR DESCRIPTION
Opening of the Undotree shouldn't affect CTRL-^ nagivation to the original alternate file, `:keepalt` fixes that.

To reproduce this, open `fileA`, then `:edit fileB`. Now open the `:UndotreeShow`. In the original buffer, `:ls` should still show the `#` sigil before `fileA`, not before `undotree_2`.

PS: Thank you for including my other two pull requests!
