### PR TITLE
Resolve Issue #36

### DIFF
--- a/plugin/undotree.vim
+++ b/plugin/undotree.vim
@@ -346,8 +346,8 @@ function! s:undotree.BindKey()
     for i in s:keymap
         silent exec 'nnoremap <silent> <script> <buffer> '.i[1].' :call <sid>undotreeAction("'.i[0].'")<cr>'
     endfor
-    if exists('*g:undotree_CustomMap')
-        call g:undotree_CustomMap()
+    if exists('*g:Undotree_CustomMap')
+        call g:Undotree_CustomMap()
     endif
 endfunction
 


### PR DESCRIPTION
Use capital character for g: functions to avoid gvim E128 error message when using CustomMap. This message comes from latest patches of vim 7.4 (1-307).
