### PR TITLE
Create a `tags` file in `doc` of the project (not in real `.vim/doc` directory)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
To begin with, I report as an issue but it's more about launching a discussion.  My case is maybe to tricky to take care.

I publish my vim files in a Git repository. I use Pathogen to manage all the plugins (you put the plugin into a subdirectory instead of unzipping it directly into `~/.vim`). I can then add the plugins as git submodules in `~/.vim/bundles/` like for example `~/.vim/bundles/undotree`. However, since the `tags` file is created into this subdirectory, the main git repository see the submodule as being modified. However, the plugin has not been modified since `tags` is not a file of the plugin, it's just something automatically generated.

Could it be possible to generate this file somewhere else, at a place where it would make sense like directly in the `~/.vim/doc` directory?
