### PR TITLE
Suppress autocmds less aggressively

### DIFF
--- a/plugin/undotree.vim
+++ b/plugin/undotree.vim
@@ -229,7 +229,7 @@ endfunction
 function! s:exec_silent(cmd)
     call s:log("s:exec_silent() ".a:cmd)
     let ei_bak= &eventignore
-    set eventignore=all
+    set eventignore=BufEnter,BufLeave,BufWinLeave,InsertLeave,CursorMoved,BufWritePost
     silent exe a:cmd
     let &eventignore = ei_bak
 endfunction


### PR DESCRIPTION
I noticed that my statusline doesn't update properly when using undotree to move between revisions of a file (https://github.com/wincent/wincent/issues/16). I established that this was because it was using `'eventignore'` to suppress all autocmds, which in turn prevents the statusline from updating.

Commenting out the `set eventignore=all` line makes the failure to update go away, at the cost of firing more autocmds.

I considered adding an option for opting out of this behavior (eg. `let g:Undotree_Eventignore=0` or something), or rearchitecting my statusline to use an approach like vim-airline does based on CursorMoved autocmds (see https://github.com/vim-airline/vim-airline/issues/82; see also https://github.com/vim-airline/vim-airline/blob/30f078daf569e7d5e4f7829e39316387af349b41/plugin/airline.vim#L36-L50 for current implementation), but then realized that a simpler fix is to have undotree just disable only the autocmds that it uses instead of disabling all of them.

This is probably not enough to unbreak every bit of code in the world that depends on those autocmds, but it does at least unbreak my use case, because it allows my `WinLeave` autocmd to run and update the statusline.