### PR TITLE
Update custom mappings in documentation

### DIFF
--- a/doc/undotree.txt
+++ b/doc/undotree.txt
@@ -317,16 +317,16 @@ Default: "DiffAdd" and "DiffChange"
 There are two ways of changing the default key mappings:
 The first way is to define global mappings as the following example:
 >
-    nmap <buffer> J <plug>UndotreeGoNextState
-    nmap <buffer> K <plug>UndotreeGoPreviousState
+    nmap <buffer> J <plug>UndotreeNextState
+    nmap <buffer> K <plug>UndotreePreviousState
 <
 A better approach is to define the callback function g:Undotree_CustomMap().
 The function will be called after the undotree windows is initialized, so the
 key mappings only works on the undotree windows.
 >
     function g:Undotree_CustomMap()
-        nmap <buffer> J <plug>UndotreeGoNextState
-        nmap <buffer> K <plug>UndotreeGoPreviousState
+        nmap <buffer> J <plug>UndotreeNextState
+        nmap <buffer> K <plug>UndotreePreviousState
     endfunc
 <
 List of the commands available for redefinition.
@@ -337,10 +337,10 @@ List of the commands available for redefinition.
     <plug>UndotreeClearHistory
     <plug>UndotreeTimestampToggle
     <plug>UndotreeDiffToggle
-    <plug>UndotreeGoNextState
-    <plug>UndotreeGoPreviousState
-    <plug>UndotreeGoNextSaved
-    <plug>UndotreeGoPreviousSaved
+    <plug>UndotreeNextState
+    <plug>UndotreePreviousState
+    <plug>UndotreeNextSavedState
+    <plug>UndotreePreviousSavedState
     <plug>UndotreeRedo
     <plug>UndotreeUndo
     <plug>UndotreeEnter


### PR DESCRIPTION
Hello,

It seems [this commit](https://github.com/mbbill/undotree/commit/a80159c9f5c238575b63984b8bc610bc5de6b233) has broken some of the `<plug>` mappings documented at `:h Undotree_CustomMap`.

This PR tries to update the documentation to reflect the new `<plug>` mappings to use to go through the history of old saved states of the buffer.

Thank you very much for your plugin.
