### PR TITLE
Adding the option for changing vertical shape in tree render

### DIFF
--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -950,7 +950,7 @@ function! s:undotree.Render() abort
                 if index == i
                     let newline = newline.g:undotree_TreeNodeShape.' '
                 else
-                    let newline = newline.'| '
+                    let newline = newline.g:undotree_TreeVertShape.' '
                 endif
             endfor
             let newline = newline.'   '.(node.seq).'    '.
@@ -971,10 +971,10 @@ function! s:undotree.Render() abort
             let newmeta = s:new(s:node) "invalid node.
             for k in range(len(slots))
                 if k < index
-                    let newline = newline."| "
+                    let newline = newline.g:undotree_TreeVertShape." "
                 endif
                 if k == index
-                    let newline = newline."|/ "
+                    let newline = newline.g:undotree_TreeVertShape."/ "
                 endif
                 if k > index
                     let newline = newline."/ "

--- a/doc/undotree.txt
+++ b/doc/undotree.txt
@@ -18,11 +18,12 @@ CONTENTS                                                   *undotree-contents*
         3.5  undotree_DiffAutoOpen .......... |undotree_DiffAutoOpen|
         3.6  undotree_SetFocusWhenToggle .... |undotree_SetFocusWhenToggle|
         3.7  undotree_TreeNodeShape ......... |undotree_TreeNodeShape|
-        3.8  undotree_DiffCommand ........... |undotree_DiffCommand|
-        3.9  undotree_RelativeTimestamp ..... |undotree_RelativeTimestamp|
-        3.10 undotree_ShortIndicators ....... |undotree_ShortIndicators|
-        3.11 undotree_HighlightChangedText .. |undotree_HighlightChangedText|
-        3.12 undotree_HighlightSyntaxAdd .... |undotree_HighlightSyntaxAdd|
+        3.8  undotree_TreeVertShape ......... |undotree_TreeNodeShape|
+        3.9  undotree_DiffCommand ........... |undotree_DiffCommand|
+        3.10  undotree_RelativeTimestamp ..... |undotree_RelativeTimestamp|
+        3.11 undotree_ShortIndicators ....... |undotree_ShortIndicators|
+        3.12 undotree_HighlightChangedText .. |undotree_HighlightChangedText|
+        3.13 undotree_HighlightSyntaxAdd .... |undotree_HighlightSyntaxAdd|
              undotree_HighlightSyntaxChange . |undotree_HighlightSyntaxChange|
         3.13 Undotree_CustomMap ............. |Undotree_CustomMap|
         3.14 undotree_HelpLine .............. |undotree_HelpLine|

--- a/doc/undotree.txt
+++ b/doc/undotree.txt
@@ -305,21 +305,28 @@ Set the tree node shape.
 Default: '*'
 
 ------------------------------------------------------------------------------
-3.8 g:undotree_DiffCommand                              *undotree_DiffCommand*
+3.8 g:undotree_TreeVertShape                          *undotree_TreeVertShape*
+
+Set the tree vertical pipe shape.
+
+Default: '|'
+
+------------------------------------------------------------------------------
+3.9 g:undotree_DiffCommand                              *undotree_DiffCommand*
 
 Set the command used to get the diff output.
 
 Default: "diff"
 
 ------------------------------------------------------------------------------
-3.9 g:undotree_RelativeTimestamp                  *undotree_RelativeTimestamp*
+3.10 g:undotree_RelativeTimestamp                  *undotree_RelativeTimestamp*
 
 Set to 1 to use relative timestamp.
 
 Default: 1
 
 ------------------------------------------------------------------------------
-3.10 g:undotree_ShortIndicators                      *undotree_ShortIndicators*
+3.11 g:undotree_ShortIndicators                      *undotree_ShortIndicators*
 
 Set to 1 to get short timestamps when |undotree_RelativeTimestamp| is also
 enabled:
@@ -339,14 +346,14 @@ enabled:
 Default: 0
 
 ------------------------------------------------------------------------------
-3.11 g:undotree_HighlightChangedText           *undotree_HighlightChangedText*
+3.12 g:undotree_HighlightChangedText           *undotree_HighlightChangedText*
 
 Set to 1 to highlight the changed text.
 
 Default: 1
 
 ------------------------------------------------------------------------------
-3.12 g:undotree_HighlightSyntaxAdd               *undotree_HighlightSyntaxAdd*
+3.13 g:undotree_HighlightSyntaxAdd               *undotree_HighlightSyntaxAdd*
      g:undotree_HighlightSyntaxChange         *undotree_HighlightSyntaxChange*
 
 Set the highlight linked syntax type.
@@ -355,7 +362,7 @@ You may chose your favorite through ":hi" command.
 Default: "DiffAdd" and "DiffChange"
 
 ------------------------------------------------------------------------------
-3.13 g:Undotree_CustomMap                                 *Undotree_CustomMap*
+3.14 g:Undotree_CustomMap                                 *Undotree_CustomMap*
 
 There are two ways of changing the default key mappings:
 The first way is to define global mappings as the following example:
@@ -390,14 +397,14 @@ List of the commands available for redefinition.
 <
 
 ------------------------------------------------------------------------------
-3.14 g:undotree_HelpLine                                   *undotree_HelpLine*
+3.15 g:undotree_HelpLine                                   *undotree_HelpLine*
 
 Set to 0 to hide "Press ? for help".
 
 Default: 1
 
 ------------------------------------------------------------------------------
-3.15 g:undotree_CursorLine
+3.16 g:undotree_CursorLine
 
 Set to 0 to disable cursorline.
 

--- a/plugin/undotree.vim
+++ b/plugin/undotree.vim
@@ -114,6 +114,11 @@ if !exists('g:undotree_TreeNodeShape')
     let g:undotree_TreeNodeShape = '*'
 endif
 
+" tree vertical shape.
+if !exists('g:undotree_TreeVertShape')
+    let g:undotree_TreeVertShape = '|'
+endif
+
 if !exists('g:undotree_DiffCommand')
     let g:undotree_DiffCommand = "diff"
 endif


### PR DESCRIPTION
Adding configuration option `g:undotree_TreeVertShape` that enables the user to set the pipe line used for rendering the tree. This partially solves #103.

## Showcase of the result:
IMHO using '│' rather than a pipe '|' looks better because it fills the whole rectangle.
![TreeVertShape_showcase](https://user-images.githubusercontent.com/56647779/109959666-1b776b00-7ce8-11eb-95ad-a19e653ef328.png)
![without_TreeVertShape_showcase](https://user-images.githubusercontent.com/56647779/109960848-8d03e900-7ce9-11eb-8494-f94fd78ea916.png)

## Caveat:
This breaks the highlighting in syntax, however this is also true for the configuration option `g:undotree_TreeNodeShape`. Do you have an idea on how to solve this @mbbill ? Should I submit an issue?