### PR TITLE
Fix set undodir. Add script to create dir if no exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,15 @@ nnoremap <F5> :UndotreeToggle<CR>
 
 ```
 if has("persistent_undo")
-    set undodir=$HOME."/.undodir"
+   let target_path = expand('~/.undodir')
+
+    " create the directory and any parent directories
+    " if the location does not exist.
+    if !isdirectory(target_path)
+        call mkdir(target_path, "p", 0700)
+    endif
+
+    let undodir=target_path
     set undofile
 endif
 ```


### PR DESCRIPTION
There was issues in README.md example:
- set undodir, instead of let
- wrong quotes after $HOME
- wrong dot after $HOME

[source](https://sidneyliebrand.io/blog/vim-tip-persistent-undo)