### PR TITLE
Fix set undodir, use dedicated syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ if has("persistent_undo")
         call mkdir(target_path, "p", 0700)
     endif
 
-    let undodir=target_path
+    let &undodir=target_path
     set undofile
 endif
 ```


### PR DESCRIPTION
Fix set undodir, for vim options, use dedicated syntax

1. let undodir=target_path, It doesn't work. It uses the working directory.
2. For vim options(e.g. undodir), use dedicated syntax (:help :let-& ), it works.