### PR TITLE
style(autoload): replace tabs with spaces and add modeline

### DIFF
--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -1422,3 +1422,4 @@ function! undotree#UndotreeFocus() abort
     endif
 endfunction
 
+" vim: set et fdm=marker sts=4 sw=4:

--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -533,11 +533,11 @@ function! s:undotree.Show() abort
     setlocal nospell
     setlocal nonumber
     setlocal norelativenumber
-	if g:undotree_CursorLine
-		setlocal cursorline
-	else
-		setlocal nocursorline
-	endif
+    if g:undotree_CursorLine
+        setlocal cursorline
+    else
+        setlocal nocursorline
+    endif
     setlocal nomodifiable
     setlocal statusline=%!t:undotree.GetStatusLine()
     setfiletype undotree


### PR DESCRIPTION
First of all, thank you for making this plugin. This is a great plugin to visualize the undo sequence.

When I tried to learn how this plugin works, I noticed that there's a tab character and the lack of modeline in autoload file.

Referencing to plugin file and syntax file, I assumed you prefer four spaces so I replaced the tabs character with four spaces. I also added the modeline in autoload file too.