### PR TITLE
Set eventignore after finding target window

### DIFF
--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -1034,11 +1034,8 @@ function! s:diffpanel.Update(seq,targetBufnr,targetid) abort
             call s:log("diff cache hit.")
             let diffresult = self.cache[a:targetBufnr.'_'.a:seq]
         else
-            let ei_bak = &eventignore
-            set eventignore=all
-            let targetWinnr = -1
-
             " Double check the target winnr and bufnr
+            let targetWinnr = -1
             for winnr in range(1, winnr('$')) "winnr starts from 1
                 if (getwinvar(winnr,'undotree_id') == a:targetid)
                             \&& winbufnr(winnr) == a:targetBufnr
@@ -1048,6 +1045,10 @@ function! s:diffpanel.Update(seq,targetBufnr,targetid) abort
             if targetWinnr == -1
                 return
             endif
+
+            let ei_bak = &eventignore
+            set eventignore=all
+
             call s:exec_silent(targetWinnr." wincmd w")
 
             " remember and restore cursor and window position.


### PR DESCRIPTION
Problem: eventignore is not restored when there is no target window.
This happens when Undotree is used on non-normal buffers (buftype is not
empty or acwrite).

Solution: Set eventignore only after finding the target window, so that
it doesn't need to be restored in such cases.