### PR TITLE
Keep `&modified` status in clearing undo history

### DIFF
--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -426,10 +426,12 @@ function! s:undotree.ActionClearHistory() abort
         return
     endif
     let ul_bak = &undolevels
+    let mod_bak = &modified
     let &undolevels = -1
     call s:exec("norm! a \<BS>\<Esc>")
     let &undolevels = ul_bak
-    unlet ul_bak
+    let &modified = mod_bak
+    unlet ul_bak mod_bak
     let self.targetBufnr = -1 "force update
     call self.Update()
 endfunction


### PR DESCRIPTION
In clearing undo history, the target buffer's `&modified` status is set unexpectedly.

It modifies the file (`norm! a \<BS>\<Esc>`) to refresh undo history
(Probably it keeps the existing history data without any modification).

```vim
"In s:undotree.ActionClearHistory()

let ul_bak = &undolevels
let &undolevels = -1
call s:exec("norm! a \<BS>\<Esc>")
let &undolevels = ul_bak
```

But this turns `&modified` status on.

So it should backup `&modified` status besides `undolevels`.

#### How to Repro

1. Open and edit a file
2. Save the file
    - Now `&modified` is not set
3. Push `[F5]` to open UndoTree window
4. Push `[C]` to clear history
    - Input `YES` to the confirmation
5. Now the file's `&modified` status is set
