### PR TITLE
fix: make undoing/redoing changes in folds visible

### DIFF
--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -206,6 +206,37 @@ function! s:log(msg) abort
     endif
 endfunction
 
+function! s:ObserveOptions()
+    augroup Undotree_OptionsObserver
+        try
+            autocmd!
+            if exists('+fdo')
+                let s:open_folds = &fdo =~# 'undo'
+                if exists('##OptionSet')
+                    autocmd OptionSet foldopen let s:open_folds = v:option_new =~# 'undo'
+                endif
+            endif
+        finally
+            augroup END
+        endtry
+endfunction
+
+" Whether to open folds on undo/redo.
+" Is 1 when 'undo' is in &fdo (see :help 'foldopen').
+" default: 1
+let s:open_folds = 1
+
+if exists('v:vim_did_enter')
+    if !v:vim_did_enter
+        autocmd VimEnter * call s:ObserveOptions()
+    else
+        call s:ObserveOptions()
+    endif
+else
+    autocmd VimEnter * call s:ObserveOptions()
+    call s:ObserveOptions()
+endif
+
 "=================================================
 "Base class for panels.
 let s:panel = {}
@@ -345,6 +376,10 @@ function! s:undotree.ActionInTarget(cmd) abort
     " Target should be a normal buffer.
     if (&bt == '' || &bt == 'acwrite') && (&modifiable == 1) && (mode() == 'n')
         call s:exec(a:cmd)
+        " Open folds so that the change being undone/redone is visible.
+        if s:open_folds
+            call s:exec('normal! zv')
+        endif
         call self.Update()
     endif
     " Update not always set current focus.


### PR DESCRIPTION
Without Undotree, Vim's default behavior upon undoing or redoing a change in the current buffer is to open any folds that contain that change so that the change is visible. This behavior is controlled by the `undo` option in `&fdo`, which is enabled by default. Undotree is currently keeping such folds closed when undoing and redoing changes from the Undotree panel, which ultimately hides the changes that are being undone or redone.

This commit:

* Brings Undotree's behavior in line with how undo/redo usually works (e.g. when using `u` or `CTRL-R` in the current buffer)

* Let's you view undo/redo changes in real time and without having to open or disable folds first, even if those changes that you are undoing/redoing (from the Undotree panel) are currently hidden in closed folds

* Respects Vim's `fdo` option, so that the user may customize this behavior