### PR TITLE
fix: set `'buftype'` to `nofile` instead of `nowrite`

### DIFF
--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -562,7 +562,7 @@ function! s:undotree.Show() abort
 
     setlocal winfixwidth
     setlocal noswapfile
-    setlocal buftype=nowrite
+    setlocal buftype=nofile
     setlocal bufhidden=delete
     setlocal nowrap
     setlocal foldcolumn=0
@@ -1277,7 +1277,7 @@ function! s:diffpanel.Show() abort
     setlocal winfixwidth
     setlocal winfixheight
     setlocal noswapfile
-    setlocal buftype=nowrite
+    setlocal buftype=nofile
     setlocal bufhidden=delete
     setlocal nowrap
     setlocal nobuflisted


### PR DESCRIPTION
For context, I have `deactivate` set to run `UndotreeHide` on exit in my `lazy.nvim` config. When this happens, and I restore the session that was automatically created with `:mks`, the window created by `undotree` still persists (ignore the strange window width as that's caused by a separate plugin):

![Kapture 2023-04-20 at 10 48 27](https://user-images.githubusercontent.com/38332081/233419746-ddb7cb7b-8b94-4818-aa58-8f1762e59349.gif)

However, if I set `'buftype'` to `nofile` before exiting, it seems to fix the problem:

![Kapture 2023-04-20 at 10 50 59](https://user-images.githubusercontent.com/38332081/233420237-814ce235-9c80-4326-a212-4a8e8e4c5169.gif)

Setting `'buftype'` to `nofile` also fixes the issue where the buffer title changes when you `:cd`, although this is minor.