### PR TITLE
Improve nvim/vim to immediately create the undofile after :UndotreePersistUndo executed.

### DIFF
--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -1463,14 +1463,24 @@ function! undotree#UndotreeFocus() abort
 endfunction
 
 function! undotree#UndotreePersistUndo(goSetUndofile = 0) abort
+    call s:log("undotree#UndotreePersistUndo(" .. a:goSetUndofile .. ")")
     if ! &undofile
         if !isdirectory(g:undotree_UndoDir)
             call mkdir(g:undotree_UndoDir, 'p', 0700)
+            call s:log(" > [Dir " .. g:undotree_UndoDir .. "] created.")
         endif
         exe "set undodir=" .. g:undotree_UndoDir
+        call s:log(" > [set undodir=" .. g:undotree_UndoDir .. "] executed.")
         if filereadable(undofile(expand('%'))) || a:goSetUndofile
             setlocal undofile
+            call s:log(" > [setlocal undofile] executed")
         endif
+        if a:goSetUndofile
+            silent! write
+            echo "A persistence undo file has been created."
+        endif
+    else
+        call s:log(" > Undofile has been set. Do nothing.")
     endif
 endfunction
 


### PR DESCRIPTION
- The undofile will only be created once the buffer has been written to the file. Therefore, it is necessary to write the buffer the first time the :UndotreePersistUndo command is called.
- Echo  "A persistence undo file has been created." once the persistence undofile has been created.
- Add debug logging in the undotree#UndotreePersistUndo function.