### PR TITLE
Fix undefined help link to undotree_UndoDir.

### DIFF
--- a/doc/undotree.txt
+++ b/doc/undotree.txt
@@ -137,7 +137,7 @@ command is executed and the persistence undofile is created, the "setlocal
 undofile" function will automatically be executed the next time the file is
 reopened.
 
-See |g:undotree_UndoDir|
+See |undotree_UndoDir|
 
 You may want to map the command to whatever hotkey by adding this following
 line to your vimrc, for instance:
@@ -443,7 +443,7 @@ Set to 0 to disable cursorline.
 Default: 1
 
 ------------------------------------------------------------------------------
-3.16 g:undotree_UndoDir
+3.16 g:undotree_UndoDir                                      *undotree_UndoDir*
 
 Set the path for the persistence undo directory. Due to the differing formats
 of the persistence undo files between nvim and vim, the default undodir for


### PR DESCRIPTION
I just noticed that I forgot to add the link ref to the undotree_UndoDir in the doc/undotree.txt file. :)