### PR TITLE
Fix the use of .. has causes errors in VIM versions < 8.0.2.

### DIFF
--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -1462,15 +1462,15 @@ function! undotree#UndotreeFocus() abort
     endif
 endfunction
 
-function! undotree#UndotreePersistUndo(goSetUndofile = 0) abort
-    call s:log("undotree#UndotreePersistUndo(" .. a:goSetUndofile .. ")")
+function! undotree#UndotreePersistUndo(goSetUndofile) abort
+    call s:log("undotree#UndotreePersistUndo(" . a:goSetUndofile . ")")
     if ! &undofile
         if !isdirectory(g:undotree_UndoDir)
             call mkdir(g:undotree_UndoDir, 'p', 0700)
-            call s:log(" > [Dir " .. g:undotree_UndoDir .. "] created.")
+            call s:log(" > [Dir " . g:undotree_UndoDir . "] created.")
         endif
-        exe "set undodir=" .. g:undotree_UndoDir
-        call s:log(" > [set undodir=" .. g:undotree_UndoDir .. "] executed.")
+        exe "set undodir=" . g:undotree_UndoDir
+        call s:log(" > [set undodir=" . g:undotree_UndoDir . "] executed.")
         if filereadable(undofile(expand('%'))) || a:goSetUndofile
             setlocal undofile
             call s:log(" > [setlocal undofile] executed")

--- a/plugin/undotree.vim
+++ b/plugin/undotree.vim
@@ -182,14 +182,14 @@ if !exists('g:undotree_UndoDir')
     let s:undoDir = &undodir
     let s:subdir = has('nvim') ? 'nvim' : 'vim'
     if s:undoDir == "."
-        let s:undoDir = $HOME .. '/.local/state/' .. s:subdir .. '/undo/'
+        let s:undoDir = $HOME . '/.local/state/' . s:subdir . '/undo/'
     endif
     let g:undotree_UndoDir = s:undoDir
 endif
 
 augroup undotreeDetectPersistenceUndo
     au!
-    au BufReadPost * call undotree#UndotreePersistUndo()
+    au BufReadPost * call undotree#UndotreePersistUndo(0)
 augroup END
 
 "=================================================


### PR DESCRIPTION
The utilization of the text concatenation operator `..` and the implementation of a default value for a function have resulted in errors in VIM versions prior to 8.0.2. Therefore, I switch to the operator `.` instead and remove the default parameter value definition.