### PR TITLE
Clarify '-n' in user commands

### DIFF
--- a/plugin/undotree.vim
+++ b/plugin/undotree.vim
@@ -14,11 +14,11 @@ let g:loaded_undotree = 0
 " Refer to https://github.com/mbbill/undotree/issues/4 for details.
 " Thanks kien
 if v:version < 703
-    command! -n=0 -bar UndotreeToggle :echoerr "undotree.vim needs Vim version >= 7.3"
+    command! -nargs=0 -bar UndotreeToggle :echoerr "undotree.vim needs Vim version >= 7.3"
     finish
 endif
 if (v:version == 703 && !has("patch005"))
-    command! -n=0 -bar UndotreeToggle :echoerr "undotree.vim needs vim7.3 with patch005 applied."
+    command! -nargs=0 -bar UndotreeToggle :echoerr "undotree.vim needs vim7.3 with patch005 applied."
     finish
 endif
 let g:loaded_undotree = 1   " Signal plugin availability with a value of 1.
@@ -194,10 +194,10 @@ augroup END
 
 "=================================================
 " User commands.
-command! -n=0 -bar UndotreeToggle      :call undotree#UndotreeToggle()
-command! -n=0 -bar UndotreeHide        :call undotree#UndotreeHide()
-command! -n=0 -bar UndotreeShow        :call undotree#UndotreeShow()
-command! -n=0 -bar UndotreeFocus       :call undotree#UndotreeFocus()
-command! -n=0 -bar UndotreePersistUndo :call undotree#UndotreePersistUndo(1)
+command! -nargs=0 -bar UndotreeToggle      :call undotree#UndotreeToggle()
+command! -nargs=0 -bar UndotreeHide        :call undotree#UndotreeHide()
+command! -nargs=0 -bar UndotreeShow        :call undotree#UndotreeShow()
+command! -nargs=0 -bar UndotreeFocus       :call undotree#UndotreeFocus()
+command! -nargs=0 -bar UndotreePersistUndo :call undotree#UndotreePersistUndo(1)
 
 " vim: set et fdm=marker sts=4 sw=4:


### PR DESCRIPTION
When I was looking at the source code for undotree, I noticed that `-n` was used within user commands.  I failed to find what this was anywhere within vim documentation or online.  As such, I looked at the vim source code.  It seems to be an undocumented "feature" where the prefix of these "context setters"/"attributes" get promoted.

I feel that using the proper name for this attribute (`-nargs`) instead of the smallest valid prefix (`-n`) would help with the readability of the source code, especially since this is an undocumented "feature" (unlike commands, which show their valid abbreviations in the helpdocs, i.e. `:g[lobal]`).

*Alternatively, every `-n=0` could be omitted entirely, since `0` is the default value (according to the helpdocs).*