### PR TITLE
fix: Update line number to options doc in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ endif
 
 #### Configuration
 
-[Here](https://github.com/mbbill/undotree/blob/master/plugin/undotree.vim#L15) is a list of options.
+[Here](https://github.com/mbbill/undotree/blob/master/plugin/undotree.vim#L27) is a list of options.
 
 #### Debug
 


### PR DESCRIPTION
The line number pointing to the options documentation was incorrect in the link (probably outdated from README changes). This PR fixes the line number in the link.

Thanks!