### PR TITLE
fix(docs): missing tag for CursorLine

### DIFF
--- a/doc/undotree.txt
+++ b/doc/undotree.txt
@@ -436,7 +436,7 @@ Set to 0 to hide "Press ? for help".
 Default: 1
 
 ------------------------------------------------------------------------------
-3.15 g:undotree_CursorLine
+3.15 g:undotree_CursorLine                                   *undotree_HelpLine*
 
 Set to 0 to disable cursorline.
 


### PR DESCRIPTION
The help tag for 3.15 was missing, and so K navigation wasn't working. Added to enhance consistency when navigating documentation. Please consider for inclusion.