### PR TITLE
Add support for custom diff marker

### DIFF
--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -1182,10 +1182,15 @@ function! s:diffpanel.Update(seq,targetBufnr,targetid,diffmark) abort
     call s:exec('1,$ d _')
 
     call append(0,diffresult)
-    if a:diffmark != -1
+    if a:diffmark == -1 || a:seq == a:diffmark
+        call append(0,'+ seq: '.a:seq.' +')
+    elseif a:seq > a:diffmark
+        call append(0,'+ seq: '.a:seq.' +')
         call append(0,'- seq: '.a:diffmark.' -')
+    else
+        call append(0,'+ seq: '.a:diffmark.' +')
+        call append(0,'- seq: '.a:seq.' -')
     endif
-    call append(0,'+ seq: '.a:seq.' +')
 
     "remove the last empty line
     if getline("$") == ""

--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -445,7 +445,7 @@ function! s:undotree.ActionDiffMark() abort
         return
     endif
     let seq = self.asciimeta[index].seq
-    if seq == -1 || seq == 0
+    if seq == -1
         return
     endif
     if seq == self.diffmark

--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -58,6 +58,7 @@ let s:helpmore = ['"    ===== Marks ===== ',
             \'" >num< : The current state',
             \'" {num} : The next redo state',
             \'" [num] : The latest state',
+            \'" =num= : The diff mark',
             \'"   s   : Saved states',
             \'"   S   : The last saved state',
             \'"   ===== Hotkeys =====']

--- a/doc/undotree.txt
+++ b/doc/undotree.txt
@@ -111,6 +111,9 @@ Markers
   * Saved changes are marked as s and the big S indicates the most recent
     saved change.
 
+  * The = number = marks user chosen change. When this mark is set the 
+    diff panel displays diff between current seq and marked seq.
+
   * Press ? in undotree window for quick help.
 
 Persistent undo
@@ -426,6 +429,8 @@ List of the commands available for redefinition.
     <plug>UndotreeRedo
     <plug>UndotreeUndo
     <plug>UndotreeEnter
+    <plug>UndotreeDiffMark
+    <plug>UndotreeClearDiffMark
 <
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Often, i find myself wanting to glance at undo diff beyond a single level. 
This PR adds additional functionality to add a custom marker for the diff view.

With diff marker set, the diff panel displays diff between current seq and marked seq.

Keymaps:
`=` - Toggles marker
`C` - Clears marker

Preview:
![image](https://github.com/user-attachments/assets/97debae2-0ff6-47d7-85b0-c62313f8177f)
