### PR TITLE
feat: add options to modify the symbols displayed in the gutter

### DIFF
--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -103,10 +103,10 @@ let s:keymap += [['Enter','<cr>','Move to the current state']]
 " it is not possible to place a sign on the exact line - because it doesn't exist.
 " Instead, a 'special' delete sign is placed on the (existing) last line of the
 " buffer)
-exe 'sign define UndotreeAdd text=++ texthl='.undotree_HighlightSyntaxAdd
-exe 'sign define UndotreeChg text=~~ texthl='.undotree_HighlightSyntaxChange
-exe 'sign define UndotreeDel text=-- texthl='.undotree_HighlightSyntaxDel
-exe 'sign define UndotreeDelEnd text=-v texthl='.undotree_HighlightSyntaxDel
+exe 'sign define UndotreeAdd text='.undotree_SignAdded.' texthl='.undotree_HighlightSyntaxAdd
+exe 'sign define UndotreeChg text='.undotree_SignChanged.' texthl='.undotree_HighlightSyntaxChange
+exe 'sign define UndotreeDel text='.undotree_SignDeleted.' texthl='.undotree_HighlightSyntaxDel
+exe 'sign define UndotreeDelEnd text='.undotree_SignDeletedEnd.' texthl='.undotree_HighlightSyntaxDel
 
 " Id to use for all signs. This is an arbitrary number that is hoped to be unique
 " within the instance of vim. There is no way of guaranteeing it IS unique, which

--- a/doc/undotree.txt
+++ b/doc/undotree.txt
@@ -27,10 +27,14 @@ CONTENTS                                                     *undotree-contents*
         3.11 undotree_HighlightChangedText .. |undotree_HighlightChangedText|
         3.12 undotree_HighlightSyntaxAdd .... |undotree_HighlightSyntaxAdd|
              undotree_HighlightSyntaxChange . |undotree_HighlightSyntaxChange|
-        3.13 Undotree_CustomMap ............. |Undotree_CustomMap|
-        3.14 undotree_HelpLine .............. |undotree_HelpLine|
-        3.15 undotree_CursorLine ............ |undotree_CursorLine|
-        3.16 undotree_UndoDir................ |undotree_UndoDir|
+        3.13 undotree_SignAdded ............. |undotree_SignAdded|
+             undotree_SignModified .......... |undotree_SignModified|
+             undotree_SignDeleted ........... |undotree_SignDeleted|
+             undotree_SignDeletedEnd ........ |undotree_SignDeletedEnd|
+        3.14 Undotree_CustomMap ............. |Undotree_CustomMap|
+        3.15 undotree_HelpLine .............. |undotree_HelpLine|
+        3.16 undotree_CursorLine ............ |undotree_CursorLine|
+        3.17 undotree_UndoDir................ |undotree_UndoDir|
     4. Bugs ................................. |undotree-bugs|
     5. Changelog ............................ |undotree-changelog|
     6. License .............................. |undotree-license|
@@ -111,7 +115,7 @@ Markers
   * Saved changes are marked as s and the big S indicates the most recent
     saved change.
 
-  * The = number = marks user chosen change. When this mark is set the 
+  * The = number = marks user chosen change. When this mark is set the
     diff panel displays diff between current seq and marked seq.
 
   * Press ? in undotree window for quick help.
@@ -397,7 +401,24 @@ You may chose your favorite through ":hi" command.
 Default: "DiffAdd", "DiffDelete" and "DiffChange"
 
 ------------------------------------------------------------------------------
-3.13 g:Undotree_CustomMap                                   *Undotree_CustomMap*
+3.13 g:undotree_SignAdded                                   *undotree_SignAdded*
+     g:undotree_SignModified                             *undotree_SignModified*
+     g:undotree_SignDeleted                               *undotree_SignDeleted*
+     g:undotree_SignDeletedEnd                         *undotree_SignDeletedEnd*
+
+Set the signs to display in the gutter where the file has been changed.
+
+SignDeletedEnd is used when the last line of the buffer has been deleted;
+it is not possible to display SignDeleted since the deleted text is actually
+beyond the end of the current buffer version and therefore it is not possible
+to place a sign on the exact line - because it doesn't exist.
+Instead, a special delete sign is placed on the (existing) last line of the
+buffer
+
+Default: "++", "~~", "--" and "-v"
+
+------------------------------------------------------------------------------
+3.14 g:Undotree_CustomMap                                   *Undotree_CustomMap*
 
 There are two ways of changing the default key mappings:
 The first way is to define global mappings as the following example:
@@ -434,21 +455,21 @@ List of the commands available for redefinition.
 <
 
 ------------------------------------------------------------------------------
-3.14 g:undotree_HelpLine                                     *undotree_HelpLine*
+3.15 g:undotree_HelpLine                                     *undotree_HelpLine*
 
 Set to 0 to hide "Press ? for help".
 
 Default: 1
 
 ------------------------------------------------------------------------------
-3.15 g:undotree_CursorLine
+3.16 g:undotree_CursorLine
 
 Set to 0 to disable cursorline.
 
 Default: 1
 
 ------------------------------------------------------------------------------
-3.16 g:undotree_UndoDir                                      *undotree_UndoDir*
+3.17 g:undotree_UndoDir                                      *undotree_UndoDir*
 
 Set the path for the persistence undo directory. Due to the differing formats
 of the persistence undo files between nvim and vim, the default undodir for

--- a/plugin/undotree.vim
+++ b/plugin/undotree.vim
@@ -160,6 +160,20 @@ if !exists('g:undotree_HighlightSyntaxDel')
     let g:undotree_HighlightSyntaxDel = "DiffDelete"
 endif
 
+" Signs to display in the gutter where the file has been modified
+if !exists('g:undotree_SignAdded')
+    let g:undotree_SignAdded = "++"
+endif
+if !exists('g:undotree_SignChanged')
+    let g:undotree_SignChanged = "~~"
+endif
+if !exists('g:undotree_SignDeleted')
+    let g:undotree_SignDeleted = "--"
+endif
+if !exists('g:undotree_SignDeletedEnd')
+    let g:undotree_SignDeletedEnd = "-v"
+endif
+
 " Deprecates the old style configuration.
 if exists('g:undotree_SplitLocation')
     echo "g:undotree_SplitLocation is deprecated,


### PR DESCRIPTION
Currently, the value of the signs displayed in the gutter of modified, deleted or added lines are hardcoded [here](https://github.com/mbbill/undotree/blob/b951b87b46c34356d44aa71886aecf9dd7f5788a/autoload/undotree.vim#L106).
This PR adds 4 options, to grant the user the ability to change them.
I called them undotreeSignAdded, undotreeSignChanged, undotreeSignDeleted and undotreeSignDeletedEnd, and their defaults are the same as they are now.