### PR TITLE
feat: add undotree_DisabledFiletypes option

### DIFF
--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -637,6 +637,11 @@ function! s:undotree.Update() abort
     if exists('b:isUndotreeBuffer')
         return
     endif
+    " let the user disable undotree for chosen filetypes
+    if index(g:undotree_DisabledFiletypes, &filetype) != -1
+        call s:log("undotree.Update() disabled filetype")
+        return
+    endif
     if (&bt != '' && &bt != 'acwrite') || (&modifiable == 0) || (mode() != 'n')
         if &bt == 'quickfix' || &bt == 'nofile'
             "Do nothing for quickfix and q:

--- a/doc/undotree.txt
+++ b/doc/undotree.txt
@@ -34,7 +34,8 @@ CONTENTS                                                     *undotree-contents*
         3.14 Undotree_CustomMap ............. |Undotree_CustomMap|
         3.15 undotree_HelpLine .............. |undotree_HelpLine|
         3.16 undotree_CursorLine ............ |undotree_CursorLine|
-        3.17 undotree_UndoDir................ |undotree_UndoDir|
+        3.17 undotree_DisabledFiletypes...... |undotree_DisabledFiletypes|
+        3.18 undotree_UndoDir................ |undotree_UndoDir|
     4. Bugs ................................. |undotree-bugs|
     5. Changelog ............................ |undotree-changelog|
     6. License .............................. |undotree-license|
@@ -469,7 +470,14 @@ Set to 0 to disable cursorline.
 Default: 1
 
 ------------------------------------------------------------------------------
-3.17 g:undotree_UndoDir                                      *undotree_UndoDir*
+3.17 g:undotree_DisabledFiletypes                  *undotree_DisabledFiletypes*
+
+List of filetypes that Undotree will ignore.
+
+Default: empty
+
+------------------------------------------------------------------------------
+3.18 g:undotree_UndoDir                                      *undotree_UndoDir*
 
 Set the path for the persistence undo directory. Due to the differing formats
 of the persistence undo files between nvim and vim, the default undodir for

--- a/plugin/undotree.vim
+++ b/plugin/undotree.vim
@@ -190,6 +190,11 @@ if !exists('g:undotree_CursorLine')
     let g:undotree_CursorLine = 1
 endif
 
+" Ignored filetypes
+if !exists('g:undotree_DisabledFiletypes')
+    let g:undotree_DisabledFiletypes = []
+endif
+
 " Define the default persistence undo directory if not defined in vim/nvim
 " startup script.
 if !exists('g:undotree_UndoDir')


### PR DESCRIPTION
Sometimes, plugins create buffers without assigning `buftype=nofile` or `buftype=nowrite` or similar; and undotree will track those, sometimes causing issues. The user should be able to disable this plugin for chosen filetypes, which is implemented by this PR.