### PR TITLE
fix: ignore events in undotree.SetTargetFocus()

### DIFF
--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -518,7 +518,7 @@ function! s:undotree.SetTargetFocus() abort
     for winnr in range(1, winnr('$')) "winnr starts from 1
         if getwinvar(winnr,'undotree_id') == self.targetid
             if winnr() != winnr
-                call s:exec("norm! ".winnr."\<c-w>\<c-w>")
+                call s:exec_silent("norm! ".winnr."\<c-w>\<c-w>")
                 return 1
             endif
         endif


### PR DESCRIPTION
`undotree.SetTargetFocus()` triggers several events that may not be desirable; for instance, most actions trigger `BufEnter` events when calling it.
I think these events should be ignored in this case, and `s:exec_silent` should be used instead of `s:exec` in `undotree.SetTargetFocus()`, unless they are are desirable in other scenarios like `Undotree.Show()` ?