### PR TITLE
feat: add undotree_StatusLine option

### DIFF
--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -607,7 +607,9 @@ function! s:undotree.Show() abort
         setlocal nocursorline
     endif
     setlocal nomodifiable
-    setlocal statusline=%!t:undotree.GetStatusLine()
+    if g:undotree_StatusLine
+        setlocal statusline=%!t:undotree.GetStatusLine()
+    endif
     setfiletype undotree
 
     call self.BindKey()
@@ -1364,7 +1366,9 @@ function! s:diffpanel.Show() abort
     setlocal norelativenumber
     setlocal nocursorline
     setlocal nomodifiable
-    setlocal statusline=%!t:diffpanel.GetStatusLine()
+    if g:undotree_StatusLine
+        setlocal statusline=%!t:diffpanel.GetStatusLine()
+    endif
 
     let &eventignore = ei_bak
 

--- a/doc/undotree.txt
+++ b/doc/undotree.txt
@@ -34,8 +34,9 @@ CONTENTS                                                     *undotree-contents*
         3.14 Undotree_CustomMap ............. |Undotree_CustomMap|
         3.15 undotree_HelpLine .............. |undotree_HelpLine|
         3.16 undotree_CursorLine ............ |undotree_CursorLine|
-        3.17 undotree_DisabledFiletypes...... |undotree_DisabledFiletypes|
-        3.18 undotree_UndoDir................ |undotree_UndoDir|
+        3.17 undotree_StatusLine ............ |undotree_StatusLine|
+        3.18 undotree_DisabledFiletypes...... |undotree_DisabledFiletypes|
+        3.19 undotree_UndoDir................ |undotree_UndoDir|
     4. Bugs ................................. |undotree-bugs|
     5. Changelog ............................ |undotree-changelog|
     6. License .............................. |undotree-license|
@@ -463,21 +464,30 @@ Set to 0 to hide "Press ? for help".
 Default: 1
 
 ------------------------------------------------------------------------------
-3.16 g:undotree_CursorLine
+3.16 g:undotree_CursorLine                                 *undotree_CursorLine*
 
 Set to 0 to disable cursorline.
 
 Default: 1
 
 ------------------------------------------------------------------------------
-3.17 g:undotree_DisabledFiletypes                  *undotree_DisabledFiletypes*
+3.17 g:undotree_StatusLine
+
+By default, Undotree will override your statusline option while in the
+Undotree buffer.
+Set to 0 to disable this.
+
+Default: 1
+
+------------------------------------------------------------------------------
+3.18 g:undotree_DisabledFiletypes                   *undotree_DisabledFiletypes*
 
 List of filetypes that Undotree will ignore.
 
 Default: empty
 
 ------------------------------------------------------------------------------
-3.18 g:undotree_UndoDir                                      *undotree_UndoDir*
+3.19 g:undotree_UndoDir                                       *undotree_UndoDir*
 
 Set the path for the persistence undo directory. Due to the differing formats
 of the persistence undo files between nvim and vim, the default undodir for

--- a/plugin/undotree.vim
+++ b/plugin/undotree.vim
@@ -190,6 +190,11 @@ if !exists('g:undotree_CursorLine')
     let g:undotree_CursorLine = 1
 endif
 
+" Set statusline
+if !exists('g:undotree_StatusLine')
+    let g:undotree_StatusLine = 1
+endif
+
 " Ignored filetypes
 if !exists('g:undotree_DisabledFiletypes')
     let g:undotree_DisabledFiletypes = []


### PR DESCRIPTION
Currently, the plugin sets the `statusline` option when entering an Undotree buffer. This PR adds an option called undotree_StatusLine, which, when set to 0, will disable this, enabling the user to override it with another statusline.