### PR TITLE
Add new option undotree_DisabledBuftypes with good defaults

### DIFF
--- a/autoload/undotree.vim
+++ b/autoload/undotree.vim
@@ -639,6 +639,11 @@ function! s:undotree.Update() abort
     if exists('b:isUndotreeBuffer')
         return
     endif
+    " let the user disable undotree for chosen buftypes
+    if index(g:undotree_DisabledBuftypes, &buftype) != -1
+        call s:log("undotree.Update() disabled buftype")
+        return
+    endif
     " let the user disable undotree for chosen filetypes
     if index(g:undotree_DisabledFiletypes, &filetype) != -1
         call s:log("undotree.Update() disabled filetype")

--- a/doc/undotree.txt
+++ b/doc/undotree.txt
@@ -36,7 +36,8 @@ CONTENTS                                                     *undotree-contents*
         3.16 undotree_CursorLine ............ |undotree_CursorLine|
         3.17 undotree_StatusLine ............ |undotree_StatusLine|
         3.18 undotree_DisabledFiletypes...... |undotree_DisabledFiletypes|
-        3.19 undotree_UndoDir................ |undotree_UndoDir|
+        3.19 undotree_DisabledBuftypes...... |undotree_DisabledBuftypes|
+        3.20 undotree_UndoDir................ |undotree_UndoDir|
     4. Bugs ................................. |undotree-bugs|
     5. Changelog ............................ |undotree-changelog|
     6. License .............................. |undotree-license|
@@ -487,7 +488,14 @@ List of filetypes that Undotree will ignore.
 Default: empty
 
 ------------------------------------------------------------------------------
-3.19 g:undotree_UndoDir                                       *undotree_UndoDir*
+3.19 g:undotree_DisabledBuftypes                   *undotree_DisabledBuftypes*
+
+List of filetypes that Undotree will ignore.
+
+Default: ['terminal', 'prompt', 'quickfix']
+
+------------------------------------------------------------------------------
+3.20 g:undotree_UndoDir                                       *undotree_UndoDir*
 
 Set the path for the persistence undo directory. Due to the differing formats
 of the persistence undo files between nvim and vim, the default undodir for

--- a/plugin/undotree.vim
+++ b/plugin/undotree.vim
@@ -200,6 +200,11 @@ if !exists('g:undotree_DisabledFiletypes')
     let g:undotree_DisabledFiletypes = []
 endif
 
+" Ignored buftypes
+if !exists('g:undotree_DisabledBuftypes')
+    let g:undotree_DisabledBuftypes = ['terminal', 'prompt', 'quickfix']
+endif
+
 " Define the default persistence undo directory if not defined in vim/nvim
 " startup script.
 if !exists('g:undotree_UndoDir')


### PR DESCRIPTION
By default, disable undotree updates for certain buffer types. This improves the overall undotree experience in Neovim, especially when used alongside some plugins.
